### PR TITLE
Finally Seeing Effects From Print CSS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <link rel="stylesheet" href="%PUBLIC_URL%/print.css" media="print">
+    
     <!-- Add Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" />
 
@@ -32,6 +32,7 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" integrity="sha384-oBqDVmMz4fnFO9gybBogGzBtAAtG+giCkhE6z+YlCfNU4l0TPzI6ucOJm8iiFuKz" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js" integrity="sha384-B4gt1jrGC7Jh4AgM7n7GILmSAW2YIj6l9kJ2aFEpB0R0FUABW76pzn1LNQ64cV9c" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="%PUBLIC_URL%/print.css" media="print">
     <title>Weekly Schedule</title>
   </head>
   <body>

--- a/public/print.css
+++ b/public/print.css
@@ -1,4 +1,21 @@
-
-#root > ul, #root > p, #root > h1, #toggle, #root > form {
+.no-print {
     display: none;
 }
+
+/* Show only elements with the print-only class */
+.print-only {
+    display: inline !important;
+}
+
+/* Ensure that certain elements within print-only sections, like table rows or cells, are shown */
+.print-only table, 
+.print-only tr, 
+.print-only td, 
+.print-only th {
+    display: table !important;
+    display: table-row !important;
+    display: table-cell !important;
+    display: table-header-group !important;
+}
+
+/* Optional: If you want to handle specific styles for certain elements within print-only, you can add more styles here */

--- a/src/Student.js
+++ b/src/Student.js
@@ -25,7 +25,7 @@ class Student extends React.Component {
             <div className="student col-lg-12 col-md-12 col-sm-12 col-12" style={{display: this.props.isVisible ? 'block' : 'none'}}>
                 <p>{this.props.studentName} is my name, my whole body's made of glitter and I throw it in your face!</p>
                 <div className="studentForm">
-                    <div className="breakfast">
+                    <div className="breakfast no-print">
                         <h2 className="student col-lg-12 col-md-12 col-sm-12 col-12">Breakfast</h2>
                         {daysOfWeek.map((item, index) => (
                             <form key={`breakfast${item}`} className="container">
@@ -49,7 +49,7 @@ class Student extends React.Component {
                             </form>
                         ))}
                     </div>
-                    <div className="lunch">
+                    <div className="lunch no-print">
                         <h2 className="student col-lg-12 col-md-12 col-sm-12 col-12">Lunch</h2>
                         {daysOfWeek.map((item, index) => (
                             <form key={`lunch${item}`} className="container">
@@ -74,7 +74,7 @@ class Student extends React.Component {
                         ))}
                     </div>
                 </div>
-                <div className="studentResults printOnly" style={{display: 'none'}}>
+                <div className="studentResults print-only">
                     <table>
                         <thead>
                             <tr>

--- a/src/index.css
+++ b/src/index.css
@@ -85,3 +85,7 @@ h2 {
   font-size: 1rem;
   text-align:  left;
 }
+
+.print-only {
+  display: none;
+}


### PR DESCRIPTION
Looks like there is some consistent behavior across the internet that Chrome is prone to having key differences happen with print media in CSS. That said, with the update contained here, it is successfully hiding the radio buttons and showing the HTML tables. Step in the right direction, need to get the formatting of the HTML table working better.