### PR TITLE
Rainbow Names

### DIFF
--- a/public/print.css
+++ b/public/print.css
@@ -33,6 +33,10 @@ h2.print-only, h2.week-header {
     font-size: 50px;
     text-align: center;
     margin: 25pt;
+    background-image: linear-gradient(to right, red, orange, yellow, green, blue, indigo, violet);
+    -webkit-background-clip: text;
+    color: transparent;
+    background-size: 15%;
 }
 
 .print-student-table {
@@ -42,7 +46,7 @@ h2.print-only, h2.week-header {
 
 th, td {
     padding: 5pt;
-    border: 2pt solid black;
+    border: 3pt solid black;
     text-align: center;
     font-size: 22pt;
     font-weight: 700;


### PR DESCRIPTION
Made further changes to the print styling to allow for rainbow colors to show on each student's name when printing out. Looks like the previous issue around screen media styling was just Chrome being confused after many attempts at rendering the print preview (along with using the print emulation).