### PR TITLE
Showing Disabled Days in Print

### DIFF
--- a/public/print.css
+++ b/public/print.css
@@ -61,6 +61,14 @@ th:not(:first-child), td:not(:first-child) {
     width: 120pt;
 }
 
+.print-day-disabled {
+    background-color: #e0e0e0;
+}
+
+tbody td.print-day-disabled {
+    font-size: 0;
+}
+
 /*testing comments*/
 
 


### PR DESCRIPTION
Successfully updated the print styling to make it clear when a day is not enabled and to not show any of the status details on those columns, while keeping the header.